### PR TITLE
Update p-ragnaroc.json

### DIFF
--- a/content/blocks/turrets/power/p-ragnaroc.json
+++ b/content/blocks/turrets/power/p-ragnaroc.json
@@ -1,51 +1,4 @@
-{
-    "health": "8789000",
-    "type": "powerTurret",
-    "reload": 740,
-    "recoil": 0,
-    "rotateSpeed": 0,
-    "canOverdrive": false,
-    "acceptsCoolant": false,
-    "shootCone": 720,
-    "shootEffect": {
-    "type": "multiEffect",
-    "lifetime": 40,
-    "effects": [
-    {
-    "type": "ParticleEffect",
-    "particles": 1,
-    "sizeFrom": 14,
-    "sizeTo": 1,
-    "length": 0,
-    "layer": 110,
-    "interp": "swingIn",
-    "lifetime": 180,
-    "colorFrom": "180F2AFF",
-    "colorTo": "180F2AFF",
-    "cone": 360
-    },
-    {
-    "type": "ParticleEffect",
-    "particles": 1,
-    "sizeFrom": 20,
-    "sizeTo": 1,
-    "length": 0,
-    "lifetime": 180,
-    "interp": "swingIn",
-    "layer": 109,
-    "colorFrom": "A170F4FF",
-    "colorTo": "A170F4FF",
-    "cone": 360
-    },
-    {
-    "type": "ParticleEffect",
-    "particles": 1,
-    "sizeFrom": 40,
-    "sizeTo": 2,
-    "length": 0,
-    "spin": 0.7,
-    "lifetime": 180,
-    "interp": "swingIn",  
+
     "layer": 109,
     "region": "exogenesis-wide",
     "colorFrom": "A170F4FF",
@@ -328,7 +281,7 @@
       "colorFrom": "9B61FFFF",
       "colorTo": "9B61FFFF"
       },
-      "damage": 300,
+      "damage": 30000,
       "speedMultiplier": 0.50,
       "healthMultiplier": 0.50,
       "reloadMultiplier": 0.50,
@@ -336,14 +289,9 @@
     }
 },
 "requirements": [
-    "surge-alloy/13750",
-    "phase-fabric/8000",
-	"thorium/9600",
-	"plastanium/7500",
-    "vurtimite/7200",
-    "rutuxium/10000",
-	"titanium/8000",
-	"osmium/9300"
+  
+	"titanium/1",
+	
 ],
 "category": "turret",
 "research": "eternity-core"


### PR DESCRIPTION

    "layer": 109,
    "region": "exogenesis-wide",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F4FF"
    },
    {
    "type": "ParticleEffect",
    "particles": 1,
    "sizeFrom": 47,
    "sizeTo": 2,
    "length": 0,
    "spin": -0.7,
    "interp": "swingIn",    
    "lifetime": 180,
    "layer": 109,
    "region": "exogenesis-tall",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F4FF"
    },
    {
    "type": "ParticleEffect",
    "particles": 35,
    "offset": 15,
    "baseLength": -65,
    "sizeFrom": 0,
    "sizeTo": 4,
    "length": 60,
    "layer": 109,
    "lightColor": "774ACFFF",
    "lifetime": 40,
    "colorFrom": "774ACFFF",
    "colorTo": "A170F4FF",
    "cone": 360
    },
    {
    "type": "ParticleEffect",
    "particles": 1,
    "sizeFrom": 50,
    "sizeTo": 0,
    "length": 0,
    "spin": 11,
    "lightColor": "774ACFFF",
    "interp": "swingIn",    
    "lifetime": 125,
    "layer": 109,
    "region": "exogenesis-runic-circle",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F4F00",
    "cone": 360
    },
    {
    "type": "ParticleEffect",
    "particles": 1,
    "sizeFrom": 30,
    "sizeTo": 0,
    "length": 0,
    "lightColor": "774ACFFF",
    "interp": "swingIn",
    "spin": -11,
    "lifetime": 125,
    "layer": 109,
    "region": "exogenesis-runic-circle",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F4F00",
    "cone": 360
    },
    {
    "type": "ParticleEffect",
    "particles": 15,
    "sizeFrom": 4.6,
    "sizeTo": 4,
    "length": 75,
    "offsetX": 2.5,
    "spin": 1,
    "lifetime": 120,
    "region": "exogenesis-rune1",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    },
    {
    "type": "ParticleEffect",
    "particles": 15,
    "sizeFrom": 4.5,
    "sizeTo": 4,
    "offsetX": 2.6,
    "length": 80,
    "spin": 1,
    "lifetime": 110,
    "region": "exogenesis-rune2",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    },
    {
    "type": "ParticleEffect",
    "particles": 15,
    "sizeFrom": 4.4,
    "sizeTo": 4,
    "offsetX": 2.7,
    "length": 85,
    "spin": 1,
    "lifetime": 100,
    "region": "exogenesis-rune3",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    },
    {
    "particles": 15,
    "sizeFrom": 4.3,
    "sizeTo": 4,
    "offsetX": 2.8,
    "length": 90,
    "spin": -1,
    "lifetime": 90,
    "region": "exogenesis-rune4",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    },
    {
    "particles": 15,
    "sizeFrom": 4.2,
    "sizeTo": 4,
    "offsetX": 2.9,
    "length": 95,
    "spin": -1,
    "lifetime": 80,
    "region": "exogenesis-rune5",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    },
    {
    "particles": 15,
    "sizeFrom": 4.1,
    "sizeTo": 4,
    "offsetX": 3,
    "length": 100,
    "spin": -1,
    "lifetime": 70,
    "region": "exogenesis-rune6",
    "colorFrom": "774ACFFF",
    "colorTo": "A170F400"
    }
    ]
    },
    "range": 1800,
    "shootY": 0,
    "heatColor": "9B61FFFF",
    "cooldown": 0.030,
    "size": 16,
    "shootSound": "release",
"shoot": {
"type": "shootPattern",
   "shots": 860
},
   
    "inaccuracy": 360,
"consumes" : {
		"power": 200
		},
    "hasPower": true,
    "shootType": {
    "sprite": "exogenesis-wavee",
    "collidesTiles": true,
    "reflectable": false,
    "hittable": false,
    "absorbable": false,
    "speed": 5,
    "height": 168,
    "hitSize": 40,
    "width": 18,
    "shrinkX": -18,
    "shrinkY": 0,
    "drawSize": 0,
    "collidesTeam": true,
    "healPercent": 1,
    "hitSize": 36,
    "pierce": true,
    "pierceCap": 30,
    "pierceBuilding": true,
    "lifetime": 1000,
    "knockback": 0,
    "ammoMultiplier": 4,
    "damage": 25000,
    "trailChance": 0.2,
    "trailEffect": {
    "type": "multiEffect",
    "lifetime": 120,
    "effects": [
    {
    "type": "ParticleEffect",
    "particles": 1,
    "sizeFrom": 3.5,
    "sizeTo": 3,
    "length": 18,
    "baseLength": 18,
    "lifetime": 30,
    "region": "exogenesis-rune2",
    "lightColor": "A170F4FF",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F400"
    },
    {
    "type": "ParticleEffect",
    "particles": 1,
    "sizeFrom": 3.4,
    "sizeTo": 3,
    "length": 18,
    "baseLength": 18,
    "lifetime": 30,
    "region": "exogenesis-rune3",
    "lightColor": "A170F4FF",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F400"
    },
    {
    "particles": 1,
    "sizeFrom": 3.3,
    "sizeTo": 3,
    "length": 18,
    "baseLength": 18,
    "lifetime": 30,
    "region": "exogenesis-rune4",
    "lightColor": "A170F4FF",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F400"
    },
    {
    "particles": 1,
    "sizeFrom": 3.2,
    "sizeTo": 3,
    "length": 18,
    "baseLength": 18,
    "lifetime": 30,
    "region": "exogenesis-rune5",
    "lightColor": "A170F4FF",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F400"
    },
    {
    "particles": 1,
    "sizeFrom": 3.1,
    "sizeTo": 3,
    "length": 18,
    "baseLength": 18,
    "lifetime": 30,
    "region": "exogenesis-rune6",
    "lightColor": "A170F4FF",
    "colorFrom": "A170F4FF",
    "colorTo": "A170F400"
    }
    ]
    },
    "frontColor": "FFFFFF",
    "backColor": "9B61FFFF",
    "hitEffect": {
    "type": "WaveEffect",
    "lifetime": 35,
    "sizeFrom": 0,
    "sizeTo": 65,
    "strokeFrom": 4,
    "strokeTo": 0,
    "colorFrom": "9B61FFFF",
    "colorTo": "9B61FFFF"
    },
    "despawnEffect": "none",
    "shootEffect": "none",
    "smokeEffect": "none",
    "incendChance": 0,
    "status": {
      "name": "choas",
      "permanent": true,
      "effect": {
      "type": "ParticleEffect",
      "line": true,
      "particles": 6,
      "lifetime": 30,
      "length": 35,
      "cone": -360,
      "lenFrom": 10,
      "lenTo": 0,
      "colorFrom": "9B61FFFF",
      "colorTo": "9B61FFFF"
      },
      "damage": 30000,
      "speedMultiplier": 0.50,
      "healthMultiplier": 0.50,
      "reloadMultiplier": 0.50,
      "damageMultiplier": 0.50
    }
},
"requirements": [
  
	"titanium/1",
	
],
"category": "turret",
"research": "eternity-core"

}
